### PR TITLE
fix cases when empty response is single space character

### DIFF
--- a/lib/restful_client.rb
+++ b/lib/restful_client.rb
@@ -107,7 +107,7 @@ module RestfulClient
       # 200, OK
       if response.success?
         logger.debug { "Success in #{method} :: Code: #{response.response_code}, #{response.body}" }
-        return '' if response.body.empty?
+        return '' if response.body.empty? || response.body == ' '
         begin
           return JSON.parse(response.body)
         rescue => e


### PR DESCRIPTION
prevents Restful-Client from throwing an exception because of the following issue:
https://github.com/rails/rails/issues/18253

e.g. using head :ok --> returns a response with single space body
